### PR TITLE
Fixed conditional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,20 +47,17 @@ class PyTest(TestCommand):
         raise SystemExit(errno)
 
 
-REQUIRES = ["pexpect >= 3.3", "six >= 1.9.0"]
-if sys.version_info < (3, 2):
-    REQUIRES.append("futures >= 2.2.0")
-if sys.version_info < (3, 3):
-    REQUIRES.append("ipaddress >= 1.0.7, < 2.0.0")
-
-
 setup(
     name="bladerunner",
     version=find_version("bladerunner/__init__.py"),
     author="Adam Talsma",
     author_email="adam@talsma.ca",
     packages=["bladerunner"],
-    install_requires=REQUIRES,
+    install_requires=["pexpect >= 3.3", "six >= 1.9.0"],
+    extras_require={
+        ":python_version < '3.2'": "futures >= 2.2.0",
+        ":python_version < '3.3'": "ipaddress >= 1.0.7, < 2.0.0",
+    },
     entry_points={
         'console_scripts': [
             'bladerunner = bladerunner.cmdline:main',


### PR DESCRIPTION
Since setup.py is not run during the installation of the wheel, it would depend on the Python version used for creating the wheel whether futures and ipaddress are included in the list of dependencies in the wheel metadata. The proper way to address this is to add them in extras_require as presented here.